### PR TITLE
[Feat] top 버튼 구현 완료

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@
 .env.development.local
 .env.test.local
 .env.production.local
+.env
 
 npm-debug.log*
 yarn-debug.log*

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,22 +1,24 @@
 import React, { useState } from 'react';
+import React, { useState } from 'react';
 import { Outlet } from 'react-router-dom';
 import Nav from './components/Nav/Nav';
 import Footer from './components/Footer/Footer';
 import ContentContainer from './components/ContentContainer/ContentContainer';
+import ContentContainer from './components/ContentContainer/ContentContainer';
 
 export default function App() {
-  const [hide, setHide] = useState(false);
+  const [show, setShow] = useState(true);
 
   const scrollHandler = (e: React.WheelEvent<HTMLDivElement>) => {
-    if (e.deltaY < 0) {
-      setHide(true);
+    if (e.deltaY > 0) {
+      setShow(false);
     } else {
-      setHide(false);
+      setShow(true);
     }
   };
   return (
     <>
-      <Nav hide={hide} />
+      <Nav show={show} />
       <ContentContainer scrollHandler={scrollHandler}>
         <Outlet />
       </ContentContainer>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,19 +1,26 @@
 import React, { useState } from 'react';
-import React, { useState } from 'react';
 import { Outlet } from 'react-router-dom';
 import Nav from './components/Nav/Nav';
 import Footer from './components/Footer/Footer';
 import ContentContainer from './components/ContentContainer/ContentContainer';
-import ContentContainer from './components/ContentContainer/ContentContainer';
+import { useRecoilState } from 'recoil';
+import { topBtnState } from './recoil/TopBtnState';
 
 export default function App() {
   const [show, setShow] = useState(true);
+  const [, setHide] = useRecoilState(topBtnState);
 
   const scrollHandler = (e: React.WheelEvent<HTMLDivElement>) => {
     if (e.deltaY > 0) {
       setShow(false);
     } else {
       setShow(true);
+    }
+
+    if (e.pageY > 700) {
+      setHide(false);
+    } else {
+      setHide(true);
     }
   };
   return (

--- a/src/components/ContentContainer/ContentContainer.tsx
+++ b/src/components/ContentContainer/ContentContainer.tsx
@@ -1,5 +1,5 @@
 import React, { ReactNode } from 'react';
-// import TopBtn from '../TopBtn/TopBtn';
+import TopBtn from '../TopBtn/TopBtn';
 
 type ScrollPorps = {
   scrollHandler: (e: React.WheelEvent<HTMLDivElement>) => void;
@@ -14,7 +14,7 @@ export default function ContentContainer({
   return (
     <div className=" h-auto relative pb-28" onWheel={scrollHandler}>
       {children}
-      {/* <TopBtn /> */}
+      <TopBtn />
     </div>
   );
 }

--- a/src/components/ContentContainer/ContentContainer.tsx
+++ b/src/components/ContentContainer/ContentContainer.tsx
@@ -12,7 +12,7 @@ export default function ContentContainer({
   children: ReactNode;
 } & ScrollPorps) {
   return (
-    <div className=" h-auto relative pb-28" onWheel={scrollHandler}>
+    <div className=" h-screen relative pb-28" onWheel={scrollHandler}>
       {children}
       <TopBtn />
     </div>

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -1,5 +1,20 @@
 import React from 'react';
 
 export default function Footer() {
-  return <div>Footer</div>;
+  return (
+    <footer className="footer footer-center p-16 bg-white  text-primary-content h-1/4">
+      <div>
+        <img
+          alt="logo"
+          src="images/meerkat.png"
+          className="inline-block fill-current w-16 h-16 text-black"
+        />
+        <p className="font-bold text-base text-black">
+          mgkkm Industries Ltd. <br />
+          Providing reliable tech since 2023
+        </p>
+        <p className="text-black mt-5">Copyright © 2023 - All right reserved</p>
+      </div>
+    </footer>
+  );
 }

--- a/src/components/Nav/Nav.tsx
+++ b/src/components/Nav/Nav.tsx
@@ -3,14 +3,14 @@ import { Link } from 'react-router-dom';
 import SideBar from './components/SideBar';
 
 interface HidePropsType {
-  hide: boolean;
+  show: boolean;
 }
 
-export default function Nav({ hide }: HidePropsType) {
+export default function Nav({ show }: HidePropsType) {
   return (
     <div
       className={`navbar bg-base-100 py-6 px-7 fixed top-0 z-10 visible transition duration-500 ease-in-out shadow  ${
-        hide && 'opacity-0'
+        show ? '' : 'opacity-0'
       }`}
     >
       <div className="navbar-start">

--- a/src/components/TopBtn/TopBtn.tsx
+++ b/src/components/TopBtn/TopBtn.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+
+export default function TopBtn() {
+  const scrollToTop = () => {
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+  };
+
+  return (
+    <button
+      onClick={scrollToTop}
+      className="btn  rounded-none bg-mkLightGray border-mkLightGray hover:bg-mkGray hover:border-mkGray fixed bottom-10 right-16"
+    >
+      <i className="fa-solid fa-angle-up text-xl text-white" />
+    </button>
+  );
+}

--- a/src/components/TopBtn/TopBtn.tsx
+++ b/src/components/TopBtn/TopBtn.tsx
@@ -1,14 +1,19 @@
 import React from 'react';
+import { useRecoilState } from 'recoil';
+import { topBtnState } from '../../recoil/TopBtnState';
 
 export default function TopBtn() {
-  const scrollToTop = () => {
+  const [hide] = useRecoilState(topBtnState);
+  const scrollToTop = (e: any) => {
     window.scrollTo({ top: 0, behavior: 'smooth' });
   };
 
   return (
     <button
       onClick={scrollToTop}
-      className="btn  rounded-none bg-mkLightGray border-mkLightGray hover:bg-mkGray hover:border-mkGray fixed bottom-10 right-16"
+      className={`${
+        hide ? 'opacity-0' : 'opacity-100'
+      } btn  rounded-none bg-mkLightGray border-mkLightGray hover:bg-mkGray hover:border-mkGray fixed bottom-10 right-16`}
     >
       <i className="fa-solid fa-angle-up text-xl text-white" />
     </button>

--- a/src/hooks/useAxios.tsx
+++ b/src/hooks/useAxios.tsx
@@ -1,0 +1,24 @@
+import React, { useState } from 'react';
+import axios from 'axios';
+
+export default function useAxios() {
+  const [data, setData] = useState<any>(null);
+  const [loading, setLoading] = useState<boolean>(false);
+  const [error, setError] = useState<string | null>('');
+
+  const fetchData = async (url: any) => {
+    try {
+      setLoading(true);
+      const response = await axios.request(url);
+      const data = response?.data;
+      setData(data);
+      return data;
+    } catch (error: any) {
+      setError(error);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return [loading, error, data, fetchData];
+}

--- a/src/recoil/NumberState.tsx
+++ b/src/recoil/NumberState.tsx
@@ -1,0 +1,28 @@
+import { atomFamily, selectorFamily } from 'recoil';
+import { toggleState } from './ToggleState';
+
+export const numberState = atomFamily<number, string>({
+  key: 'numberState',
+  default: undefined,
+});
+
+export const numberSelector = selectorFamily({
+  key: 'numberSelector',
+  get:
+    (type: string) =>
+    ({ get }) => {
+      return get(numberState(`${type}`));
+    },
+  set:
+    (type: string) =>
+    ({ get, set }, newValue) => {
+      const prevValue = get(numberState(`${type}`));
+      if (prevValue === undefined) {
+        set(numberState(`${type}`), newValue);
+      } else {
+        get(toggleState(`${type}`)) === true
+          ? set(numberState(`${type}`), prevValue - 1)
+          : set(numberState(`${type}`), prevValue + 1);
+      }
+    },
+});

--- a/src/recoil/ToggleState.tsx
+++ b/src/recoil/ToggleState.tsx
@@ -1,0 +1,25 @@
+import { atomFamily, selectorFamily } from 'recoil';
+
+export const toggleState = atomFamily<boolean, string>({
+  key: 'toggleState',
+  default: undefined,
+});
+
+export const toggleSelector = selectorFamily({
+  key: 'toggleSelector',
+  get:
+    (type: string) =>
+    ({ get }) => {
+      return get(toggleState(`${type}`));
+    },
+  set:
+    (type: string) =>
+    ({ get, set }, newState) => {
+      const preState = get(toggleState(`${type}`));
+      if (preState === undefined) {
+        set(toggleState(`${type}`), newState);
+      } else {
+        set(toggleState(`${type}`), !get(toggleState(`${type}`)));
+      }
+    },
+});

--- a/src/recoil/TopBtnState.tsx
+++ b/src/recoil/TopBtnState.tsx
@@ -1,0 +1,6 @@
+import { atom } from 'recoil';
+
+export const topBtnState = atom<boolean>({
+  key: 'topBtnState',
+  default: true,
+});


### PR DESCRIPTION
## :: 최근 작업 주제 
- [x] 기능 추가
- [ ] 리뷰 반영
- [x] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표
- 깔끔한 레이아웃
- window객체를 활용하여 버튼 클릭시 맨위로 올라가는 기능 구현 
- pageY 사용해서 스크롤의 위치 감지하여 탑버튼 보여주는 기능 구현


<br />

## :: 구현 사항 설명
**1. tailwind CSS + daisy UI 라이브러리를 활용한 레이아웃 구현**

**2. window객체를 활용하여 버튼 클릭시 맨위로 올라가는 기능 구현**
-  window 객체의 scrollTo 옵션을 사용하여 탑버튼 클릭시 top: 0의 위치로 smooth하게 올라갈수 있도록 기능 구현 완료

**3. pageY 사용해서 스크롤의 위치 감지하여 탑버튼 보여주는 기능 구현**
- pageY를 사용해서 스크롤의 위치를 감지하여 스크롤의 위치가 브라우저의 700 이상으로 내려오는 경우에만 top버튼 보여주도록 구현 완료


<br />

## :: 나만의 포인트
- 스크롤 위치 감지해서 탑버튼 보여주기 기능 구현할때 처음에는 screenY로 스크롤의 위치를 파악했는데, 알고 보니 screenY는 모니터 기준으로 스크롤의 위치를 알려주고, pageY는 **전체 문서를 기준**으로 스크롤의 위치를 알려주는 기능이었다. 

<br />
