### PR TITLE
[Feat] pageY로 스크롤 위치 감지 후 탑버튼 보여주기 기능 구현 완료

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,15 +3,24 @@ import { Outlet } from 'react-router-dom';
 import Nav from './components/Nav/Nav';
 import Footer from './components/Footer/Footer';
 import ContentContainer from './components/ContentContainer/ContentContainer';
+import { useRecoilState } from 'recoil';
+import { topBtnState } from './recoil/TopBtnState';
 
 export default function App() {
   const [show, setShow] = useState(true);
+  const [, setHide] = useRecoilState(topBtnState);
 
   const scrollHandler = (e: React.WheelEvent<HTMLDivElement>) => {
     if (e.deltaY > 0) {
       setShow(false);
     } else {
       setShow(true);
+    }
+
+    if (e.pageY > 700) {
+      setHide(false);
+    } else {
+      setHide(true);
     }
   };
   return (

--- a/src/components/ContentContainer/ContentContainer.tsx
+++ b/src/components/ContentContainer/ContentContainer.tsx
@@ -1,5 +1,5 @@
 import React, { ReactNode } from 'react';
-// import TopBtn from '../TopBtn/TopBtn';
+import TopBtn from '../TopButton/TopBtn';
 
 type ScrollPorps = {
   scrollHandler: (e: React.WheelEvent<HTMLDivElement>) => void;
@@ -14,7 +14,7 @@ export default function ContentContainer({
   return (
     <div className=" h-auto relative pb-28" onWheel={scrollHandler}>
       {children}
-      {/* <TopBtn /> */}
+      <TopBtn />
     </div>
   );
 }

--- a/src/components/TopButton/TopBtn.tsx
+++ b/src/components/TopButton/TopBtn.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { useRecoilState } from 'recoil';
+import { topBtnState } from '../../recoil/TopBtnState';
+
+export default function TopBtn() {
+  const [hide] = useRecoilState(topBtnState);
+  const scrollToTop = (e: any) => {
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+  };
+
+  return (
+    <button
+      onClick={scrollToTop}
+      className={`${
+        hide ? 'opacity-0' : 'opacity-100'
+      } btn  rounded-none bg-mkLightGray border-mkLightGray hover:bg-mkGray hover:border-mkGray fixed bottom-10 right-16`}
+    >
+      <i className="fa-solid fa-angle-up text-xl text-white" />
+    </button>
+  );
+}

--- a/src/recoil/TopBtnState.tsx
+++ b/src/recoil/TopBtnState.tsx
@@ -1,0 +1,6 @@
+import { atom } from 'recoil';
+
+export const topBtnState = atom<boolean>({
+  key: 'topBtnState',
+  default: true,
+});


### PR DESCRIPTION
## :: 최근 작업 주제 
- [x] 기능 추가
- [ ] 리뷰 반영
- [x] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표
- 깔끔한 레이아웃
- window객체를 활용하여 버튼 클릭시 맨위로 올라가는 기능 구현 
- pageY 사용해서 스크롤의 위치 감지하여 탑버튼 보여주는 기능 구현


<br />

## :: 구현 사항 설명
**1. tailwind CSS + daisy UI 라이브러리를 활용한 레이아웃 구현**

**2. window객체를 활용하여 버튼 클릭시 맨위로 올라가는 기능 구현**
-  window 객체의 scrollTo 옵션을 사용하여 탑버튼 클릭시 top: 0의 위치로 smooth하게 올라갈수 있도록 기능 구현 완료

**3. pageY 사용해서 스크롤의 위치 감지하여 탑버튼 보여주는 기능 구현**
- pageY를 사용해서 스크롤의 위치를 감지하여 스크롤의 위치가 브라우저의 700 이상으로 내려오는 경우에만 top버튼 보여주도록 구현 완료


<br />

## :: 나만의 포인트
- 스크롤 위치 감지해서 탑버튼 보여주기 기능 구현할때 처음에는 screenY로 스크롤의 위치를 파악했는데, 알고 보니 screenY는 모니터 기준으로 스크롤의 위치를 알려주고, pageY는 **전체 문서를 기준**으로 스크롤의 위치를 알려주는 기능이었다. 

<br />
