### PR TITLE
[Feat] 공통 alert 함수 생성 완료

### DIFF
--- a/src/components/Alert/Modal.tsx
+++ b/src/components/Alert/Modal.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+
+const Swal = require('sweetalert2');
+
+//(navigate)버튼 2개 가진 경고창 함수나 이벤트를 인자로 받음
+export const failedNavigateAlert = (
+  title: string,
+  text: string,
+  where: string,
+  navigate: any
+) => {
+  Swal.fire({
+    title: title,
+    text: text,
+    icon: 'warning',
+    confirmButtonText: 'Login',
+    confirmButtonColor: '#e35c02',
+    focusDeny: true,
+    showDenyButton: true,
+    denyButtonText: 'Cancel',
+    denyButtonColor: '#707070',
+    showCancelButton: false,
+  }).then((result: any) => {
+    result.isConfirmed && navigate(where);
+  });
+};
+
+//(navigate)버튼 2개 가진 경고창 함수나 이벤트를 인자로 받음
+export const failedAxiosAlert = (
+  title: string,
+  text: string,
+  axiosFunction: any
+) => {
+  Swal.fire({
+    title: title,
+    text: text,
+    icon: 'warning',
+    confirmButtonText: 'Login',
+    confirmButtonColor: '#e35c02',
+    focusDeny: true,
+    showDenyButton: true,
+    denyButtonText: 'Cancel',
+    denyButtonColor: '#707070',
+    showCancelButton: false,
+  }).then((result: any) => {
+    result.isConfirmed && axiosFunction();
+  });
+};
+
+//일반 경고창 버튼 ok 한개
+export const warningAlert = (title: string, text: string) => {
+  Swal.fire({
+    title: title,
+    text: text,
+    icon: 'warning',
+    confirmButtonText: 'OK',
+    confirmButtonColor: '#e35c02',
+    showCancelButton: false,
+  });
+};
+
+//확인 알림창
+export const infoAlert = (title: string, text: string) => {
+  Swal.fire(title, text, 'info');
+};


### PR DESCRIPTION
## :: 최근 작업 주제
- [x] 레이아웃 추가
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [x] 컨벤션 수정
<br />

## :: 구현 목표
- sweet alert 라이브러리를 이용해 반복적으로 사용되는 모달창 공통 함수로 만들기
<br />

## :: 구현 사항 설명
**1. sweet alert 라이브러리를 이용해 반복적으로 사용되는 모달창 공통 함수로 만들기**
- 함수의 인자로 title / text / naviagate / fetchData 함수를 props로 받아 여러 컴포넌트에서 확장성을 갖고 사용할 수 있게 구현
-  navigate / axiosFn 은 기능별로 다르게 동작하는 함수를 생성
<br />


## :: 성장 포인트
- 처음에 공통적으로 사용되는 alert을 만들고 싶어서 라이브러리를 사용해서 만들었는데 여러 어려움이 많아서 만들기를 실패했다. 그치만 sweetAlert을 이용해 만들어 볼 수 있어서 좋았다
<br />