### PR TITLE
[Fix] 영화 디테일 페이지 블로그 데이터 및 반응형 수정

### DIFF
--- a/src/components/Comment/components/CommentList.tsx
+++ b/src/components/Comment/components/CommentList.tsx
@@ -1,7 +1,7 @@
 import { useEffect } from 'react';
 import { useLocation, useParams } from 'react-router-dom';
 import { useRecoilState, useRecoilValue, useSetRecoilState } from 'recoil';
-import { commentState } from '../../../recoil/CommentState';
+import { CommentData, commentState } from '../../../recoil/CommentState';
 import DropDownBtn from './DropDownBtn';
 import { currentUserIdState } from '../../../recoil/JwtDecode';
 import { displayCreatedAt } from '../../CreatedAt/CreatedAt';
@@ -10,6 +10,10 @@ import { renderingState } from '../../../recoil/BlogPostState';
 import { numberState } from '../../../recoil/NumberState';
 
 const BASE_URL = process.env.REACT_APP_BASE_URL;
+
+interface CommentListData {
+  data: CommentData[];
+}
 
 export default function CommentList() {
   const param = useParams();
@@ -30,7 +34,7 @@ export default function CommentList() {
   useEffect(() => {
     fetchData({
       url: getAxiosUrl,
-    }).then((data: any) => {
+    }).then((data: CommentListData) => {
       setCommentData(data.data);
       setCommentN(data.data.length);
     });

--- a/src/pages/MovieDetail/MovieDetail.tsx
+++ b/src/pages/MovieDetail/MovieDetail.tsx
@@ -12,7 +12,6 @@ import {
   movieBlogState,
   playlistYoutubeState,
 } from '../../recoil/MovieDetailState';
-import { CommentData } from '../../recoil/CommentState';
 import {
   currentUserIdState,
   currentUserNicknameState,
@@ -68,10 +67,7 @@ export interface PlaylistYoutubeData extends MainYoutubeData {
 interface MovieDetailData {
   data: {
     movieInfo: MovieHeaderData;
-    andMore: {
-      movieTrailerComments: CommentData[];
-      blogLikesAndPopularitySorting: MovieBlogData[];
-    };
+    andMore: MovieBlogData[];
     mainYoutube: MainYoutubeData;
     playlistYoutube: PlaylistYoutubeData[];
   };
@@ -117,7 +113,7 @@ export default function MovieDetail() {
         const { movieInfo, andMore, mainYoutube, playlistYoutube } =
           result.data;
         setMovieHeaderData(movieInfo);
-        setMovieBlogData(andMore.blogLikesAndPopularitySorting);
+        setMovieBlogData(andMore);
         setMainVideoId(mainYoutube.videoId);
         setPlaylistYoutubeData(playlistYoutube);
         setIsMovieLiked(movieInfo.isLikedByThisUser);

--- a/src/pages/MovieDetail/components/MovieDetailBlog.tsx
+++ b/src/pages/MovieDetail/components/MovieDetailBlog.tsx
@@ -7,7 +7,7 @@ export default function MovieDetailBlog() {
   const movieBlogData = useRecoilValue(movieBlogState);
 
   return (
-    <div className="w-full flex justify-center flex-wrap gap-9">
+    <div className="w-full grid grid-cols-1 justify-items-center gap-9 md:max-lg:grid-cols-2 xl:grid-cols-2">
       {movieBlogData?.map(blogPost => {
         return <MovieDetailBlogCard key={blogPost.id} blogPost={blogPost} />;
       })}

--- a/src/pages/MovieDetail/components/MovieDetailBlogCard.tsx
+++ b/src/pages/MovieDetail/components/MovieDetailBlogCard.tsx
@@ -16,7 +16,7 @@ export default function MovieDetailBlogCard({ blogPost }: MovieBlogCardProps) {
 
   return (
     <div
-      className="w-[23rem] h-52 flex mb-10 bg-white relative drop-shadow-md"
+      className="w-[23rem] h-52 flex mb-10 bg-white relative drop-shadow-md md:max-lg:w-[20rem] md:max-lg:h-44"
       key={id}
       onMouseOver={() => setBlogHover(true)}
       onMouseLeave={() => setBlogHover(false)}
@@ -39,7 +39,7 @@ export default function MovieDetailBlogCard({ blogPost }: MovieBlogCardProps) {
         </div>
       </div>
       {blogHover && (
-        <div className="w-[23rem] h-52 bg-white opacity-90 absolute cursor-pointer">
+        <div className="w-[23rem] h-52 bg-white opacity-90 absolute cursor-pointer md:max-lg:w-[20rem] md:max-lg:h-44">
           <div className="mt-12 h-[50px] flex flex-col justify-center text-center">
             <p className="text-ml font-semibold px-12 box-content overflow-hidden text-ellipsis line-clamp-2 underline underline-offset-4">
               {title}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -19,6 +19,7 @@ module.exports = {
     },
     screens: {
       xl: '1280px',
+      lg: '1024px',
       md: '768px',
       sm: '640px',
       xs: '414px',


### PR DESCRIPTION
## :: 최근 작업 주제
- [ ] 레이아웃 추가
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [x] 버그 수정
- [ ] 컨벤션 수정
-<br />

## :: 구현 목표
1. 영화 디테일 페이지 버그 수정
2. 블로그 카드 반응형 수정
<br />

## :: 구현 사항 설명
1. 영화 디테일 페이지 버그 수정
- 댓글 데이터 API 가 영화 디테일 페이지 데이터와 분리 / 영화 디테일 페이지 데이터 및 타입 수정
<br />

2. 블로그 카드 반응형 수정
- grid 사용하여 기본 grid-cols-1 / md:max-lg:grid-cols-2 / xl:grid-cols-2 적용함
<br />

## :: 코드 기록
<br />

## :: 알게 된 점
- grid 는 flex 와 같이 쓸 수 없음 / flex justify-center 대신 grid justify-items-center 적용해야 함 (tailwind)
<br />

## :: 기타
<br />
