### PR TITLE
[Feat] 영화 디테일 페이지 Skeleton Loading 기능 구현

### DIFF
--- a/src/components/Skeleton/MovieDetailSkeleton.tsx
+++ b/src/components/Skeleton/MovieDetailSkeleton.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+
+export function MoviePlayerSkeleton() {
+  return (
+    <div
+      role="status"
+      className="flex items-center justify-center w-full h-[630px] bg-gray-300 animate-pulse dark:bg-gray-700"
+    >
+      <svg
+        className="w-12 h-12 text-gray-200 dark:text-gray-600"
+        xmlns="http://www.w3.org/2000/svg"
+        aria-hidden="true"
+        fill="currentColor"
+        viewBox="0 0 384 512"
+      >
+        <path d="M361 215C375.3 223.8 384 239.3 384 256C384 272.7 375.3 288.2 361 296.1L73.03 472.1C58.21 482 39.66 482.4 24.52 473.9C9.377 465.4 0 449.4 0 432V80C0 62.64 9.377 46.63 24.52 38.13C39.66 29.64 58.21 29.99 73.03 39.04L361 215z" />
+      </svg>
+    </div>
+  );
+}
+
+export function PlaylistSkeleton() {
+  return (
+    <div className="flex items-center h-28">
+      <div className="flex items-center justify-center w-[168px] h-[96px] bg-gray-300 dark:bg-gray-500 animate-pulse" />
+      <div className="px-3 w-[78%] h-[96px] lg:w-[259px] animate-pulse">
+        <div className="h-4 bg-gray-200 rounded-full dark:bg-gray-700 mb-1.5" />
+        <div className="h-4 bg-gray-200 rounded-full dark:bg-gray-700 w-4/5" />
+        <div className="h-4 bg-gray-200 rounded-full dark:bg-gray-700 w-2/3 mt-3" />
+        <div className="flex">
+          <div className="h-3 bg-gray-200 rounded-full dark:bg-gray-700 w-1/4 mt-2" />
+          <div className="h-3 bg-gray-200 rounded-full dark:bg-gray-700 w-1/3 ml-2 mt-2" />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/MovieDetail/MovieDetail.tsx
+++ b/src/pages/MovieDetail/MovieDetail.tsx
@@ -17,6 +17,7 @@ import {
   currentUserNicknameState,
 } from '../../recoil/JwtDecode';
 import { DecodeToken } from '../../components/DecodeToken/DecodeToken';
+import { MoviePlayerSkeleton } from '../../components/Skeleton/MovieDetailSkeleton';
 
 export interface MovieHeaderData {
   category: {
@@ -52,6 +53,7 @@ export interface MovieBlogData {
   weeklyLikeCount: number;
   blogLikes: number;
 }
+
 interface MainYoutubeData {
   videoId: string;
 }
@@ -93,6 +95,7 @@ export default function MovieDetail() {
   const setIsMovieLiked = useSetRecoilState(
     toggleSelector(`movieLike${postId}`)
   );
+  const setMoreArrowToggle = useSetRecoilState(toggleSelector('moreArrow'));
 
   const resetMovieHeaderState = useResetRecoilState(movieHeaderState);
   const resetMovieBlogState = useResetRecoilState(movieBlogState);
@@ -117,6 +120,7 @@ export default function MovieDetail() {
         setMainVideoId(mainYoutube.videoId);
         setPlaylistYoutubeData(playlistYoutube);
         setIsMovieLiked(movieInfo.isLikedByThisUser);
+        setMoreArrowToggle(false);
         DecodeToken(setCurrentId, setCurrentNickname);
       }
     });
@@ -128,19 +132,23 @@ export default function MovieDetail() {
       resetPlaylistYoutubeState();
       resetIsMovieLiked();
     };
-  }, []);
+  }, [postId]);
 
   return (
     <div className="container xl pt-24">
-      <div className="h-[630px] w-full">
-        <MoviePlayer videoId={mainVideoId} height="630" autoplay={1} />
-      </div>
+      {loading || !mainVideoId ? (
+        <MoviePlayerSkeleton />
+      ) : (
+        <div className="h-[630px] w-full">
+          <MoviePlayer videoId={mainVideoId} height="630" autoplay={1} />
+        </div>
+      )}
       <div className="lg:flex justify-around gap-5 mt-5">
         <div className="movieDetailLeft w-full lg:w-2/3 max-lg:mb-24">
           <MovieDetailHeader />
           <MovieDetailTab />
         </div>
-        <TrailerPlaylist />
+        <TrailerPlaylist loading={loading} />
       </div>
     </div>
   );

--- a/src/pages/MovieDetail/components/RelatedVideo.tsx
+++ b/src/pages/MovieDetail/components/RelatedVideo.tsx
@@ -36,10 +36,10 @@ export default function RelatedVideo({
 
   return (
     <div className="flex items-center h-28" key={videoId}>
-      <div className="h-[96px] w-[168px] relative">
+      <div className="w-[168px] h-[96px] relative">
         <img src={thumbnail} alt="thumbnail" className="w-full h-full" />
         <div
-          className="h-full w-full bg-black absolute top-0 opacity-10 hover:opacity-50 hover:cursor-pointer"
+          className="w-full h-full bg-black absolute top-0 opacity-10 hover:opacity-50 hover:cursor-pointer"
           onClick={() => setIsModalOpen(true)}
         />
       </div>
@@ -50,9 +50,9 @@ export default function RelatedVideo({
           modalTop={modalTop}
         />
       )}
-      <div className="px-3 w-[78%] lg:w-[259px]">
+      <div className="px-3 w-[78%] h-[96px] lg:w-[259px]">
         <p
-          className="font-semibold h-12 overflow-hidden text-ellipsis line-clamp-2 hover:underline hover:underline-offset-4 hover:cursor-pointer"
+          className="font-semibold overflow-hidden text-ellipsis line-clamp-2 hover:underline hover:underline-offset-4 hover:cursor-pointer"
           onClick={() => setIsModalOpen(true)}
         >
           {title}

--- a/src/pages/MovieDetail/components/TrailerPlaylist.tsx
+++ b/src/pages/MovieDetail/components/TrailerPlaylist.tsx
@@ -1,21 +1,26 @@
 import React from 'react';
 import { useRecoilValue } from 'recoil';
+import { PlaylistSkeleton } from '../../../components/Skeleton/MovieDetailSkeleton';
 import { playlistYoutubeState } from '../../../recoil/MovieDetailState';
 import RelatedVideo from './RelatedVideo';
 
-export default function TrailerPlaylist() {
+export default function TrailerPlaylist({ loading }: { loading: boolean }) {
   const playlistYoutubeData = useRecoilValue(playlistYoutubeState);
+
+  const playlistSkeletons = Array.from({ length: 10 }, (_, index) => (
+    <PlaylistSkeleton key={index} />
+  ));
 
   return (
     <div className="flex-row lg:w-[427px] max-lg:px-5">
-      {playlistYoutubeData.map(relatedVideoData => {
-        return (
-          <RelatedVideo
-            key={relatedVideoData.videoId}
-            relatedVideoData={relatedVideoData}
-          />
-        );
-      })}
+      {loading || !playlistYoutubeData
+        ? playlistSkeletons
+        : playlistYoutubeData.map(relatedVideoData => (
+            <RelatedVideo
+              key={relatedVideoData.videoId}
+              relatedVideoData={relatedVideoData}
+            />
+          ))}
     </div>
   );
 }

--- a/src/recoil/MovieDetailState.tsx
+++ b/src/recoil/MovieDetailState.tsx
@@ -50,16 +50,7 @@ export const movieBlogState = atom<MovieBlogData[]>({
 
 export const playlistYoutubeState = atom<PlaylistYoutubeData[]>({
   key: 'playlistYoutubeState',
-  default: [
-    {
-      videoId: '',
-      title: '',
-      channel: '',
-      thumbnail: '',
-      viewCount: '',
-      publishedAt: '',
-    },
-  ],
+  default: undefined,
 });
 
 export const playerRefState = atom({


### PR DESCRIPTION
## :: 최근 작업 주제
- [x] 레이아웃 추가
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [x] 버그 수정
- [ ] 컨벤션 수정
-<br />

## :: 구현 목표
1. 영화 디테일 페이지 Skeleton Loading 기능 구현
<br />

## :: 구현 사항 설명
1. 영화 디테일 페이지 Skeleton Loading 기능 구현
- 검색창에서 useNavigate 로 페이지 이동 시 첫 번째 렌더링에서 에러 발생 / useEffect 로 데이터를 받아오기 전에 생기는 일시적 에러이므로 Skeleton Loading 컴포넌트를 생성하여 사용자 경험을 개선하고자 함
- MoviePlayer 와 TrailerPlaylist UI 에 맞는 Skeleton 컴포넌트를 생성
- MoviePlayer: fetchData() status 가 loading (true) 이거나 !mainVideoId 일 때 (undefined 또는 falsy한 값) Skeleton 컴포넌트 렌더링
- TrailerPlaylist: fetchData() status 가 loading (true) 이거나 !playlistYoutubeData 일 때 (undefined 또는 falsy한 값) Skeleton 컴포넌트 렌더링
<br />

## :: 코드 기록
<br />

## :: 알게 된 점
<br />

## :: 기타
<br />
