### PR TITLE
[Fix] 블로그 메인페이지 My blog 조건부 렌더링 구현

### DIFF
--- a/src/pages/Blog/BlogMain/components/BlogArticle.tsx
+++ b/src/pages/Blog/BlogMain/components/BlogArticle.tsx
@@ -9,9 +9,11 @@ interface BlogArticleProps {
   blogDate: number;
   commentCount: number;
   nickname: string;
-  weeklyLikeCount: number;
+  likeCount: number;
   spoiler_info_id: number;
 }
+
+// likeCount 로 바꾸기
 
 export const BlogArticle = memo((props: BlogArticleProps) => {
   const navigate = useNavigate();
@@ -23,7 +25,7 @@ export const BlogArticle = memo((props: BlogArticleProps) => {
     blogDate,
     commentCount,
     nickname,
-    weeklyLikeCount,
+    likeCount,
     spoiler_info_id,
   } = props;
 
@@ -58,7 +60,7 @@ export const BlogArticle = memo((props: BlogArticleProps) => {
               postId={`${id}`}
               btnSize="text-xl"
             />
-            <span className="text-base ml-2">{weeklyLikeCount}</span>
+            <span className="text-base ml-2">{likeCount}</span>
           </div>
         </div>
       </div>

--- a/src/pages/Blog/BlogMain/components/BlogMainTop.tsx
+++ b/src/pages/Blog/BlogMain/components/BlogMainTop.tsx
@@ -1,14 +1,46 @@
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { useResetRecoilState, useSetRecoilState } from 'recoil';
+import { myblogArticleDataState } from '../../../../recoil/ArticleDataState';
+import { toggleSelector } from '../../../../recoil/ToggleState';
+import useAxios from '../../../../hooks/useAxios';
 import Search from './Search';
 import { warningAlert } from '../../../../components/Alert/Modal';
 
+type dataType = {
+  data: {
+    thisUserWrittenPosts: [];
+  };
+};
+
 export default function BlogMainTop() {
+  const BASE_URL = process.env.REACT_APP_BASE_URL;
+  const [loading, error, data, fetchData] = useAxios();
+  const setMyblogBtn = useSetRecoilState(toggleSelector('My blog'));
+  const setMyblogData = useSetRecoilState(myblogArticleDataState);
+  const resetMyblogData = useResetRecoilState(myblogArticleDataState);
   const navigate = useNavigate();
   const [activeTab, setActiveTab] = useState(1);
+  const token = sessionStorage.getItem('token');
 
   const tabClickHandler = (id: number, title: string) => {
     setActiveTab(id);
+
+    if (title === 'My blog') {
+      fetchData({
+        url: `${BASE_URL}/blog/main/mypost?take=6&skip=0`,
+        method: 'POST',
+        headers: {
+          Authorization: token,
+        },
+      }).then((res: dataType) => {
+        setMyblogData(res);
+        setMyblogBtn(true);
+      });
+    } else {
+      setMyblogBtn(false);
+      resetMyblogData();
+    }
   };
 
   const isUser = () => {

--- a/src/pages/Blog/BlogMain/components/BlogRenderArticle.tsx
+++ b/src/pages/Blog/BlogMain/components/BlogRenderArticle.tsx
@@ -1,17 +1,60 @@
 import { useEffect } from 'react';
 import { useRecoilState, useRecoilValue, useSetRecoilState } from 'recoil';
-import { ArticleDataState } from '../../../../recoil/ArticleDataState';
+import {
+  ArticleDataState,
+  myblogArticleDataState,
+} from '../../../../recoil/ArticleDataState';
 import { toggleSelector } from '../../../../recoil/ToggleState';
 import { tokenState } from '../../../../recoil/TokenState';
 import useAxios from '../../../../hooks/useAxios';
 import { BlogArticle } from './BlogArticle';
 import { blogCreatedAt } from '../../../../components/CreatedAt/CreatedAt';
 
+type dataType = {
+  data: {
+    category: [];
+    nonSpoPostData: [];
+    spoPostData: [];
+    spoilerInfo: [];
+  };
+};
+
+type elType = {
+  category_id: number;
+  commentCount: number;
+  created_at: string;
+  id: number;
+  likeCount: number;
+  spoiler_info_id: number;
+  thumbnail: string;
+  title: string;
+  user: {
+    nickname: string;
+  };
+  weeklyLikeCount: number;
+};
+
+type myBlogElType = {
+  category_id: number;
+  commentCount: number;
+  created_at: string;
+  id: number;
+  likeCount: number;
+  spoiler_info_id: number;
+  thumbnail: string;
+  title: string;
+  user: {
+    nickname: string;
+  };
+};
+
 export default function BlogRenderArticle() {
   const BASE_URL = process.env.REACT_APP_BASE_URL;
   const [loading, error, data, fetchData] = useAxios();
   const [articleData, setArticleData] = useRecoilState(ArticleDataState);
   const toggle = useRecoilValue(toggleSelector('spo'));
+  const myBlogBtn = useRecoilValue(toggleSelector('My blog'));
+  const myBlogData = useRecoilValue(myblogArticleDataState);
 
   // token 관리 및 저장
   const setTokenValue = useSetRecoilState(tokenState);
@@ -23,7 +66,7 @@ export default function BlogRenderArticle() {
       url: `${BASE_URL}/blog/main?take=6&skip=0`,
       method: 'POST',
       headers: { Authorization: token },
-    }).then((res: any) => {
+    }).then((res: dataType) => {
       setArticleData(res);
     });
   }, [toggle]);
@@ -34,33 +77,61 @@ export default function BlogRenderArticle() {
 
   return (
     <section className="mt-14 xl:mt-10 z-10">
-      {spoToggle?.map((el: any) => {
-        const nickname = el.user.nickname;
-        const blogDate = blogCreatedAt(el.created_at);
+      {myBlogBtn
+        ? myBlogData?.data?.thisUserWrittenPosts.map((el: myBlogElType) => {
+            const nickname = el.user.nickname;
+            const blogDate = blogCreatedAt(el.created_at);
 
-        const {
-          id,
-          thumbnail,
-          title,
-          commentCount,
-          weeklyLikeCount,
-          spoiler_info_id,
-        } = el;
+            const {
+              id,
+              thumbnail,
+              title,
+              commentCount,
+              spoiler_info_id,
+              likeCount,
+            } = el;
 
-        return (
-          <BlogArticle
-            key={id}
-            id={id}
-            title={title}
-            thumbnail={thumbnail}
-            nickname={nickname}
-            commentCount={commentCount}
-            blogDate={blogDate}
-            weeklyLikeCount={weeklyLikeCount}
-            spoiler_info_id={spoiler_info_id}
-          />
-        );
-      })}
+            return (
+              <BlogArticle
+                key={id}
+                id={id}
+                title={title}
+                thumbnail={thumbnail}
+                nickname={nickname}
+                commentCount={commentCount}
+                blogDate={blogDate}
+                likeCount={likeCount}
+                spoiler_info_id={spoiler_info_id}
+              />
+            );
+          })
+        : spoToggle?.map((el: elType) => {
+            const nickname = el.user.nickname;
+            const blogDate = blogCreatedAt(el.created_at);
+
+            const {
+              id,
+              thumbnail,
+              title,
+              commentCount,
+              likeCount,
+              spoiler_info_id,
+            } = el;
+
+            return (
+              <BlogArticle
+                key={id}
+                id={id}
+                title={title}
+                thumbnail={thumbnail}
+                nickname={nickname}
+                commentCount={commentCount}
+                blogDate={blogDate}
+                likeCount={likeCount}
+                spoiler_info_id={spoiler_info_id}
+              />
+            );
+          })}
     </section>
   );
 }

--- a/src/pages/Blog/BlogMain/components/BlogScrollArticle.tsx
+++ b/src/pages/Blog/BlogMain/components/BlogScrollArticle.tsx
@@ -1,16 +1,63 @@
 import { useEffect, useRef, useState } from 'react';
-import { useRecoilValue } from 'recoil';
+import { useRecoilState, useRecoilValue } from 'recoil';
 import { toggleSelector } from '../../../../recoil/ToggleState';
+import { scrollArticleDataState } from '../../../../recoil/ArticleDataState';
 import useAxios from '../../../../hooks/useAxios';
 import { BlogArticle } from './BlogArticle';
 import { blogCreatedAt } from '../../../../components/CreatedAt/CreatedAt';
+
+type elType = {
+  data: {
+    nonSpoPostData: [
+      category_id: number,
+      commentCount: number,
+      created_at: string,
+      id: number,
+      likeCount: number,
+      spoiler_info_id: number,
+      thumbnail: string,
+      title: string,
+      user: {
+        nickname: string;
+      }
+    ];
+    spoPostData: [
+      category_id: number,
+      commentCount: number,
+      created_at: string,
+      id: number,
+      likeCount: number,
+      spoiler_info_id: number,
+      thumbnail: string,
+      title: string,
+      user: {
+        nickname: string;
+      }
+    ];
+  };
+};
+
+// type elelType = {
+//   category_id: number;
+//   commentCount: number;
+//   created_at: string;
+//   id: number;
+//   likeCount: number;
+//   spoiler_info_id: number;
+//   thumbnail: string;
+//   title: string;
+//   user: {
+//     nickname: string;
+//   };
+// };
 
 // Intersection Observer API 를 활용한 무한스크롤 페이지네이션
 export default function BlogScrollArticle() {
   const BASE_URL = process.env.REACT_APP_BASE_URL;
   const [loading, error, data, fetchData] = useAxios();
   const pageEnd = useRef<any>();
-  const [articles, setArticles] = useState([] as any); // article list
+  const [articles, setArticles] = useRecoilState(scrollArticleDataState);
+  const myBlogBtn = useRecoilValue(toggleSelector('My blog'));
   const [page, setPage] = useState<number>(1); // 현재 페이지
   const [load, setLoad] = useState<boolean>(false); // 로딩 성공, 실패를 담을 sstate
   let [offset, setOffset] = useState<number>(6); // offset 상태관리
@@ -54,38 +101,39 @@ export default function BlogScrollArticle() {
   return (
     <>
       <section>
-        {articles?.map((el: any) => {
-          const nonSpoData = el?.data?.nonSpoPostData;
-          const spoData = el?.data?.spoPostData;
-          const spoToggleData = toggle ? spoData : nonSpoData;
-          return spoToggleData?.map((el: any) => {
-            const nickname = el.user.nickname;
-            const blogDate = blogCreatedAt(el.created_at);
+        {myBlogBtn ||
+          articles?.map((el: elType) => {
+            const nonSpoData = el?.data?.nonSpoPostData;
+            const spoData = el?.data?.spoPostData;
+            const spoToggleData = toggle ? spoData : nonSpoData;
+            return spoToggleData?.map((el: any) => {
+              const nickname = el.user.nickname;
+              const blogDate = blogCreatedAt(el.created_at);
 
-            const {
-              id,
-              thumbnail,
-              title,
-              commentCount,
-              weeklyLikeCount,
-              spoiler_info_id,
-            } = el;
+              const {
+                id,
+                thumbnail,
+                title,
+                commentCount,
+                likeCount,
+                spoiler_info_id,
+              } = el;
 
-            return (
-              <BlogArticle
-                key={id}
-                id={id}
-                title={title}
-                thumbnail={thumbnail}
-                nickname={nickname}
-                commentCount={commentCount}
-                blogDate={blogDate}
-                weeklyLikeCount={weeklyLikeCount}
-                spoiler_info_id={spoiler_info_id}
-              />
-            );
-          });
-        })}
+              return (
+                <BlogArticle
+                  key={id}
+                  id={id}
+                  title={title}
+                  thumbnail={thumbnail}
+                  nickname={nickname}
+                  commentCount={commentCount}
+                  blogDate={blogDate}
+                  likeCount={likeCount}
+                  spoiler_info_id={spoiler_info_id}
+                />
+              );
+            });
+          })}
       </section>
 
       {/* observer */}

--- a/src/pages/Blog/BlogMain/components/BlogSearchArticle.tsx
+++ b/src/pages/Blog/BlogMain/components/BlogSearchArticle.tsx
@@ -1,6 +1,6 @@
 import { useRecoilValue } from 'recoil';
-import { BlogArticle } from './BlogArticle';
 import { SearchDataState } from '../../../../recoil/SearchDataState';
+import { BlogArticle } from './BlogArticle';
 import { blogCreatedAt } from '../../../../components/CreatedAt/CreatedAt';
 
 export default function BlogSearchArticle() {
@@ -17,7 +17,7 @@ export default function BlogSearchArticle() {
           thumbnail,
           title,
           commentCount,
-          weeklyLikeCount,
+          likeCount,
           spoiler_info_id,
         } = el;
 
@@ -30,7 +30,7 @@ export default function BlogSearchArticle() {
             nickname={nickname}
             commentCount={commentCount}
             blogDate={blogDate}
-            weeklyLikeCount={weeklyLikeCount}
+            likeCount={likeCount}
             spoiler_info_id={spoiler_info_id}
           />
         );

--- a/src/pages/Blog/BlogMain/components/BlogSpoToggle.tsx
+++ b/src/pages/Blog/BlogMain/components/BlogSpoToggle.tsx
@@ -1,12 +1,13 @@
 import { memo } from 'react';
-import { useRecoilState } from 'recoil';
+import { useRecoilState, useRecoilValue } from 'recoil';
 import { toggleSelector } from '../../../../recoil/ToggleState';
 
 export const BlogSpoToggle = memo(() => {
   const [toggle, setToggle] = useRecoilState(toggleSelector('spo'));
+  const myBlogBtn = useRecoilValue(toggleSelector('My blog'));
 
   return (
-    <div className="spo-toggle inline-block mx-6">
+    <div className={`spo-toggle ${myBlogBtn ? 'hidden' : 'inline-block'} mx-6`}>
       <label className="label">
         <span
           className={`label-text text-xl font-semibold mr-3 ${

--- a/src/recoil/ArticleDataState.tsx
+++ b/src/recoil/ArticleDataState.tsx
@@ -4,3 +4,13 @@ export const ArticleDataState = atom<any>({
   key: 'ArticleDataState',
   default: [],
 });
+
+export const scrollArticleDataState = atom<any>({
+  key: 'scrollArticleDataState',
+  default: [],
+});
+
+export const myblogArticleDataState = atom<any>({
+  key: 'myblogArticleDataState',
+  default: [],
+});


### PR DESCRIPTION
## :: 최근 작업 주제
- [ ] 레이아웃 추가
- [x] 기능 추가
- [ ] 리뷰 반영
- [x] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정
<br />

## :: 구현 목표
- My blog 탭 누를 때 내가 쓴 블로그만 렌더링 되도록 구현 (조건부 렌더링)
<br />

## :: 구현 사항 설명

**1. 조건부 렌더링 기능 구현**
- 'My blog'라는 탭을 클릭하면, 이름이 'My blog'로 변합니다.
- 해당 탭의 이름이 'My blog'로 변할 때에(==클릭할때에) 백엔드에서 POST 로 데이터를 받아옵니다.
- 내가 쓴 블로그 데이터만 받아오기 위해서, session storage 에 저장돼있는 token을 헤더에 넣어 보내줍니다.
- 백엔드에서는 해당 토큰으로 고유한 유저를 찾아, 그 유저가 가지고있는 id가 작성한 블로그 데이터를 선별하여 담아 보내줍니다.
- My blog 탭 클릭 시, 받아온 데이터만 렌더링 될 수 있도록, jsx 에 조건을 걸어주어, 조건에 맞게 알맞은 데이터들이 렌더링 되도록 구현했습니다.
- My blog 관련 데이터만 저장 및 관리할 수 있는 recoil state 를 생성하여 사용하였습니다.
- My blog 렌더링 시, 스포/논스포 를 관리하지 않기로 기획했기 때문에, style 을 hidden 으로 주었습니다.

<br />

## :: 코드 기록
<br />

## :: 나만의 포인트
- 조건부 렌더링은 기본이면서 많이 쓰이는데, 현재 내가 짠 코드들은 복잡해 보인다. 유지보수를 쉽게 만들어야 될 것 같은 필요성을 느낀다. 클린코드 !!!
<br />

## :: 리뷰 시 참고할 점
<br />
