### PR TITLE
[Fix] 좋아요 카운터 및 하트 상태 연결

### DIFF
--- a/src/pages/Blog/BlogMain/components/BlogArticle.tsx
+++ b/src/pages/Blog/BlogMain/components/BlogArticle.tsx
@@ -1,6 +1,9 @@
-import { memo } from 'react';
+import { memo, useEffect } from 'react';
 import LikeScrapBtn from '../../../../components/LikeScrapBtn/LikeScrapBtn';
 import { useNavigate } from 'react-router-dom';
+import { useRecoilState, useSetRecoilState } from 'recoil';
+import { numberState } from '../../../../recoil/NumberState';
+import { toggleState } from '../../../../recoil/ToggleState';
 
 interface BlogArticleProps {
   id: number;
@@ -10,10 +13,9 @@ interface BlogArticleProps {
   commentCount: number;
   nickname: string;
   likeCount: number;
+  isLikedByThisUser: boolean;
   spoiler_info_id: number;
 }
-
-// likeCount 로 바꾸기
 
 export const BlogArticle = memo((props: BlogArticleProps) => {
   const navigate = useNavigate();
@@ -26,8 +28,19 @@ export const BlogArticle = memo((props: BlogArticleProps) => {
     commentCount,
     nickname,
     likeCount,
+    isLikedByThisUser,
     spoiler_info_id,
   } = props;
+
+  const setLikeToggle = useSetRecoilState(toggleState(`blogLike${id}`));
+  const [likeNumber, setLikeNumber] = useRecoilState(
+    numberState(`blogLike${id}`)
+  );
+
+  useEffect(() => {
+    setLikeNumber(likeCount);
+    setLikeToggle(isLikedByThisUser);
+  }, []);
 
   const toBlogDetail = () => {
     navigate(`/blogDetail/${id}`);
@@ -60,7 +73,7 @@ export const BlogArticle = memo((props: BlogArticleProps) => {
               postId={`${id}`}
               btnSize="text-xl"
             />
-            <span className="text-base ml-2">{likeCount}</span>
+            <span className="text-base ml-2">{likeNumber || 0}</span>
           </div>
         </div>
       </div>

--- a/src/pages/Blog/BlogMain/components/BlogRenderArticle.tsx
+++ b/src/pages/Blog/BlogMain/components/BlogRenderArticle.tsx
@@ -25,6 +25,7 @@ type elType = {
   created_at: string;
   id: number;
   likeCount: number;
+  isLikedByThisUser: boolean;
   spoiler_info_id: number;
   thumbnail: string;
   title: string;
@@ -40,6 +41,7 @@ type myBlogElType = {
   created_at: string;
   id: number;
   likeCount: number;
+  isLikedByThisUser: boolean;
   spoiler_info_id: number;
   thumbnail: string;
   title: string;
@@ -89,6 +91,7 @@ export default function BlogRenderArticle() {
               commentCount,
               spoiler_info_id,
               likeCount,
+              isLikedByThisUser,
             } = el;
 
             return (
@@ -101,6 +104,7 @@ export default function BlogRenderArticle() {
                 commentCount={commentCount}
                 blogDate={blogDate}
                 likeCount={likeCount}
+                isLikedByThisUser={isLikedByThisUser}
                 spoiler_info_id={spoiler_info_id}
               />
             );
@@ -115,6 +119,7 @@ export default function BlogRenderArticle() {
               title,
               commentCount,
               likeCount,
+              isLikedByThisUser,
               spoiler_info_id,
             } = el;
 
@@ -128,6 +133,7 @@ export default function BlogRenderArticle() {
                 commentCount={commentCount}
                 blogDate={blogDate}
                 likeCount={likeCount}
+                isLikedByThisUser={isLikedByThisUser}
                 spoiler_info_id={spoiler_info_id}
               />
             );

--- a/src/pages/Blog/BlogMain/components/BlogScrollArticle.tsx
+++ b/src/pages/Blog/BlogMain/components/BlogScrollArticle.tsx
@@ -116,6 +116,7 @@ export default function BlogScrollArticle() {
                 title,
                 commentCount,
                 likeCount,
+                isLikedByThisUser,
                 spoiler_info_id,
               } = el;
 
@@ -129,6 +130,7 @@ export default function BlogScrollArticle() {
                   commentCount={commentCount}
                   blogDate={blogDate}
                   likeCount={likeCount}
+                  isLikedByThisUser={isLikedByThisUser}
                   spoiler_info_id={spoiler_info_id}
                 />
               );

--- a/src/pages/Blog/BlogMain/components/BlogSearchArticle.tsx
+++ b/src/pages/Blog/BlogMain/components/BlogSearchArticle.tsx
@@ -18,6 +18,7 @@ export default function BlogSearchArticle() {
           title,
           commentCount,
           likeCount,
+          isLikedByThisUser,
           spoiler_info_id,
         } = el;
 
@@ -31,6 +32,7 @@ export default function BlogSearchArticle() {
             commentCount={commentCount}
             blogDate={blogDate}
             likeCount={likeCount}
+            isLikedByThisUser={isLikedByThisUser}
             spoiler_info_id={spoiler_info_id}
           />
         );


### PR DESCRIPTION
수정 전:
좋아요 하트 버튼과 카운터가 연결되어있지 않음

수정 후:
좋아요 하트와 카운터를 연결시키고, 좋아요 눌렀는지 안눌렀는지 상태를 백에 저장하여, 새로고침 시에 잘 받아와 렌더링 되도록 수정