### PR TITLE
fix: 메인 탭 container xl 사이즈 도르마무 / tailwind.config.js 에서 xxl 사이즈 삭제

### DIFF
--- a/src/pages/Main/components/MainTab.tsx
+++ b/src/pages/Main/components/MainTab.tsx
@@ -19,7 +19,7 @@ export default function MainTab() {
   const tabClickHandler = (idx: number) => setActiveTab(idx);
 
   return (
-    <div className="max-w-[1280px] m-auto">
+    <div className="container xl">
       <h1 className="text-center font-[ChosunGs] xs:text-lg xs:mb-5 sm:mb-10 sm:text-2xl xl:text-4xl xl:mb-20">
         Meet Your Next Movie
       </h1>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -18,7 +18,6 @@ module.exports = {
       },
     },
     screens: {
-      xxl: '1500px',
       xl: '1280px',
       lg: '1024px',
       md: '768px',


### PR DESCRIPTION
이전 blogMain2 브랜치에서 해당 수정사항 적용시켰으나, 충돌로 인해 올바로 반영되지 않아,
다시 새로운 브랜치를 파서, 진경님 수정사항 적용 완료

메인 탭 container xl 사이즈로 도르마무
tailwind.config.js 에서 xxl 사이즈 제거 (다른 페이지 사이즈에 영향을 주어 삭제하기로 함)