### PR TITLE
[Refactor] toggleSelector 및 numberSelector 사용 수정

### DIFF
--- a/src/pages/Blog/BlogDetail/BlogDetail.tsx
+++ b/src/pages/Blog/BlogDetail/BlogDetail.tsx
@@ -1,7 +1,7 @@
 import { useEffect } from 'react';
 import { useResetRecoilState, useSetRecoilState } from 'recoil';
-import { toggleSelector } from '../../../recoil/ToggleState';
-import { numberSelector, numberState } from '../../../recoil/NumberState';
+import { toggleState } from '../../../recoil/ToggleState';
+import { numberState } from '../../../recoil/NumberState';
 import useAxios from '../../../hooks/useAxios';
 import { useParams } from 'react-router-dom';
 import BlogHeader from './components/BlogHeader';
@@ -52,19 +52,17 @@ export default function BlogDetail() {
 
   const setBlogDetailData = useSetRecoilState(blogDetailState);
 
-  const setIsLiked = useSetRecoilState(toggleSelector(`blogLike${postId}`));
-  const setIsScraped = useSetRecoilState(toggleSelector(`blogScrap${postId}`));
+  const setIsLiked = useSetRecoilState(toggleState(`blogLike${postId}`));
+  const setIsScraped = useSetRecoilState(toggleState(`blogScrap${postId}`));
+  const setLikeN = useSetRecoilState(numberState(`blogLike${postId}`));
+  const setScrapN = useSetRecoilState(numberState(`blogScrap${postId}`));
 
-  const setLikeN = useSetRecoilState(numberSelector(`blogLike${postId}`));
-  const setScrapN = useSetRecoilState(numberSelector(`blogScrap${postId}`));
+  const resetIsLiked = useResetRecoilState(toggleState(`blogLike${postId}`));
+  const resetIsScraped = useResetRecoilState(toggleState(`blogScrap${postId}`));
+  const resetLikeN = useResetRecoilState(numberState(`blogLike${postId}`));
+  const resetScrapN = useResetRecoilState(numberState(`blogScrap${postId}`));
 
   const resetBlogDetailState = useResetRecoilState(blogDetailState);
-  const resetIsLiked = useResetRecoilState(toggleSelector(`blogLike${postId}`));
-  const resetIsScraped = useResetRecoilState(
-    toggleSelector(`blogScrap${postId}`)
-  );
-  const resetLikeN = useResetRecoilState(numberSelector(`blogLike${postId}`));
-  const resetScrapN = useResetRecoilState(numberSelector(`blogScrap${postId}`));
   const resetCommentN = useResetRecoilState(
     numberState(`blogComment${postId}`)
   );
@@ -79,10 +77,6 @@ export default function BlogDetail() {
     }).then((result: ResultData) => {
       if (result) {
         setBlogDetailData(result.data.postDetails);
-        resetIsLiked();
-        resetIsScraped();
-        resetLikeN();
-        resetScrapN();
         setIsLiked(result.data.postDetails.isLikedByThisUser);
         setIsScraped(result.data.postDetails.isScrapedByThisUser);
         setLikeN(result.data.postDetails.likeCount);
@@ -92,6 +86,10 @@ export default function BlogDetail() {
     });
 
     return () => {
+      resetIsLiked();
+      resetIsScraped();
+      resetLikeN();
+      resetScrapN();
       resetBlogDetailState();
       resetCommentN();
     };

--- a/src/pages/Blog/BlogDetail/components/BlogFooter.tsx
+++ b/src/pages/Blog/BlogDetail/components/BlogFooter.tsx
@@ -2,15 +2,15 @@ import { FaRegCommentDots } from 'react-icons/fa';
 import { useParams } from 'react-router-dom';
 import { useRecoilValue } from 'recoil';
 import LikeScrapBtn from '../../../../components/LikeScrapBtn/LikeScrapBtn';
-import { numberSelector } from '../../../../recoil/NumberState';
+import { numberState } from '../../../../recoil/NumberState';
 
 export default function BlogFooter() {
   const params = useParams();
   const postId = params.id;
 
-  const likeN = useRecoilValue(numberSelector(`blogLike${postId}`));
-  const scrapN = useRecoilValue(numberSelector(`blogScrap${postId}`));
-  const commentN = useRecoilValue(numberSelector(`blogComment${postId}`));
+  const likeN = useRecoilValue(numberState(`blogLike${postId}`));
+  const scrapN = useRecoilValue(numberState(`blogScrap${postId}`));
+  const commentN = useRecoilValue(numberState(`blogComment${postId}`));
 
   return (
     <div className="mt-16 mb-5 text-sm flex justify-end items-center">

--- a/src/pages/MovieDetail/MovieDetail.tsx
+++ b/src/pages/MovieDetail/MovieDetail.tsx
@@ -6,7 +6,7 @@ import TrailerPlaylist from './components/TrailerPlaylist';
 import { useParams } from 'react-router-dom';
 import useAxios from '../../hooks/useAxios';
 import { useResetRecoilState, useSetRecoilState } from 'recoil';
-import { toggleSelector } from '../../recoil/ToggleState';
+import { toggleState } from '../../recoil/ToggleState';
 import {
   movieHeaderState,
   movieBlogState,
@@ -96,15 +96,13 @@ export default function MovieDetail() {
   const setMovieBlogData = useSetRecoilState(movieBlogState);
   const [mainVideoId, setMainVideoId] = useState('');
   const setPlaylistYoutubeData = useSetRecoilState(playlistYoutubeState);
-  const setIsMovieLiked = useSetRecoilState(
-    toggleSelector(`movieLike${postId}`)
-  );
+  const setIsMovieLiked = useSetRecoilState(toggleState(`movieLike${postId}`));
 
   const resetMovieHeaderState = useResetRecoilState(movieHeaderState);
   const resetMovieBlogState = useResetRecoilState(movieBlogState);
   const resetPlaylistYoutubeState = useResetRecoilState(playlistYoutubeState);
   const resetIsMovieLiked = useResetRecoilState(
-    toggleSelector(`movieLike${postId}`)
+    toggleState(`movieLike${postId}`)
   );
 
   useEffect(() => {


### PR DESCRIPTION
## :: 최근 작업 주제
- [ ] 레이아웃 추가
- [ ] 기능 추가
- [ ] 리뷰 반영
- [x] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정
<br />

## :: 구현 목표
1. toggleSelector 및 numberSelector 사용 수정
<br />

## :: 구현 사항 설명
1. toggleSelector 및 numberSelector 사용 수정
- toggleSelector 및 numberSelector 의 getter 를 의도했는데 useSetRecoilState 를 사용하고 있어서 setter 가 실행되고 있었음 (페이지 마운트 시 상태 초기화가 필요했던 이유)
- toggleState 와 numberState 로 변경하고 페이지가 언마운트 될 때 초기화 / selector 는 LikeScrapBtn.tsx 의 버튼 클릭 시 실행되는 로직에서만 사용되도록 수정
<br />

## :: 코드 기록
<br />

## :: 알게 된 점
<br />

## :: 기타
<br />
